### PR TITLE
run ED for selected samples only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# dnanexus_ED_cnv_analysis_v1.5.0
+# dnanexus_ED_cnv_analysis_v1.6.0
 Performs CNV calling using ExomeDepth.
 
 Exome depth is run in two stages. Firstly, read counts are calculated, before CNVs are called using the read counts. Read counts are calculated over the entire genome whereas the CNV calling can be performed using a subpanel.
@@ -19,6 +19,7 @@ For further details on the usage of the docker image please refer to https://git
 - Readcount file generated using https://github.com/moka-guys/dnanexus\_ED\_readcount_analysis
 - List of comma seperated pan numbers (Pan4127,Pan4129,Pan4130,Pan4049)
 - Test specific BED file
+- Optional: list of comma separated samples to run a specific sample or a list of samples only. Use the sample name before the Pan number (e.g. NGS629_01_xxxxxx_NA12878_U_VCP2R208ViaGP08,NGS629_02_xxxxxx_NA12878_U_VCP2R208ViaGP08)
 - reference genome file (hs37d5.fa.gz)
 - Bam string to download bam(s)
 - Sample string to get basename of sample
@@ -38,8 +39,7 @@ See CLI command below for an example of inputs.
 The app can be run from the dx CLI.  The example below shows the code used to run test samples through this app:
 
 ```bash
-dx run applet-GybZV0006bZFBzgf54KP7BKj -iproject_name=003_220103_exomeDepth_calling_test -ireadcount_file=project-G6jb1k807Xjj1J984K6kfP13:file-G6kg5q80gvvz37qZ4ZPbvZ8Q -ibamfile_pannumbers=Pan4127,Pan4129,Pan4130,Pan4049 -isubpanel_bed=project-ByfFPz00jy1fk6PjpZ95F27J:file-G6kZpqQ0jy1q1Zk94G3qbVyV -ireference_genome=project-ByfFPz00jy1fk6PjpZ95F27J:file-B6ZY7VG2J35Vfvpkj8y0KZ01 -ibam_str="markdup" -isample_str="_markdup.bam"
-```
+dx run applet-GybZV0006bZFBzgf54KP7BKj -iproject_name=003_220103_exomeDepth_calling_test -ireadcount_file=project-G6jb1k807Xjj1J984K6kfP13:file-G6kg5q80gvvz37qZ4ZPbvZ8Q -ibamfile_pannumbers=Pan4127,Pan4129,Pan4130,Pan4049 -isubpanel_bed=project-ByfFPz00jy1fk6PjpZ95F27J:file-G6kZpqQ0jy1q1Zk94G3qbVyV -ireference_genome=project-ByfFPz00jy1fk6PjpZ95F27J:file-B6ZY7VG2J35Vfvpkj8y0KZ01 -ibam_str="markdup" -isamplename_str="_markdup.bam" -iincluded_samples=NGS629_01_xxxxxx_NA12878_U_VCP2R208ViaGP08,NGS629_02_xxxxxx_NA12878_U_VCP2R208ViaGP08```
 # Debugging
 
 For debugging issues with the `docker` image it can be helpful to `ssh` into a 'held for debugging' job in DNA nexus and run the `docker` image in interactive mode:

--- a/dxapp.json
+++ b/dxapp.json
@@ -1,9 +1,9 @@
 {
-  "name": "ED_cnv_calling_v1.5.0",
-  "title": "ED_cnv_calling_v1.5.0",
-  "summary": "v1.5.0 - Performs CNV calling using ExomeDepth",
+  "name": "ED_cnv_calling_v1.6.0",
+  "title": "ED_cnv_calling_v1.6.0",
+  "summary": "v1.6.0 - Performs CNV calling using ExomeDepth",
   "properties": {
-    "github release": "v1.5.0"
+    "github release": "v1.6.0"
   },
   "dxapi": "1.0.0",
   "inputSpec": [
@@ -68,6 +68,13 @@
       "class": "file",
       "patterns": ["*.bed"],
       "optional": false
+    },
+    {
+      "name": "included_samples",
+      "label": "included samples",
+      "class": "string",
+      "optional": true,
+      "help": "comma separated sample name(s) to be included"
     }
   ],
   "outputSpec": [

--- a/src/code.sh
+++ b/src/code.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# exomedepth_cnv_analysis_v1.5.0
+# exomedepth_cnv_analysis_v1.6.0
 
 # The following line causes bash to exit at any point if there is any error
 # and to output each line as it is executed -- useful for debugging
@@ -65,9 +65,16 @@ mark-section "download bams files and indexes"
 IFS=',' read -ra pannum_array <<<  $bamfile_pannumbers
 for panel in "${pannum_array[@]}"; do
  	
-if [[ " ${pans_from_bams[*]} " =~ " ${panel} " ]]; then
-    # If requested pan number has matching bam files
+if [[ " ${pans_from_bams[*]} " =~ " ${panel} " ]] && [[ ! "$included_samples" ]]; then
+    # If requested pan number has matching bam files and included_samples is not provided
 	dx download "$project_name":output/*"$panel"*$bam_str.ba* --auth "$API_KEY"
+elif [[ " ${pans_from_bams[*]} " =~ " ${panel} " ]] && [[ "$included_samples" ]]; then
+    # If requested pan number has matching bam files and included_samples is provided
+	IFS=',' read -ra included_samples_array <<<  $included_samples
+	for sample in ${included_samples_array[@]}
+	do  
+	    dx download "$project_name":output/"$sample"*"$panel"*$bam_str.ba* --auth "$API_KEY"
+	done
 else
     echo "WARNING: No bam/bai files found for ${panel}"
 fi
@@ -129,7 +136,7 @@ echo "RDATA = " "$readcount_file_name"
 docker run -v /home/dnanexus:/home/dnanexus/ \
 	--rm  ${DOCKERIMAGENAME} \
 	exomeDepth.R \
-	'v1.5.0' \
+	'v1.6.0' \
 	/home/dnanexus/out/exomedepth_output/exomedepth_output/"$samplename"_output.pdf \
 	/home/dnanexus/in/subpanel_bed/"$subpanel_bed_name":"$subpanel_bed_prefix" \
 	/home/dnanexus/in/readcount_file/"$readcount_file_name" "$bam":"$samplename":0.01 $QC_file


### PR DESCRIPTION
Current ED app runs all samples with the same Pannumber. For re-analysis, not all samples are required to re-run, and re-running all samples with the same Pannumber generates unnecessary data. Therefore, a feature was added so that only a sample or list of samples that are required to re-analyse can be run selectively. 

Changes:
- Added a piece of code in code.sh to download the required bam only if the optional input (included_samples) is provided
- Added an optional input for included_samples in dxapp.json
- Updated Readme file to reflect the changes. 

The updated script was used to build a new app and tested. It was confirmed that if the optional input "included_samples" is provided, only the provided sample(s) are processed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moka-guys/dnanexus_ED_cnv_calling/15)
<!-- Reviewable:end -->
